### PR TITLE
Fix array initialization to set configured port number.

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConnection.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConnection.java
@@ -42,7 +42,7 @@ public class GrouperConnection {
     private static Connection initialize(GrouperConfiguration configuration) {
         final PGConnectionPoolDataSource dataSource = new PGConnectionPoolDataSource();
         Connection connection;
-        dataSource.setPortNumbers(new int[Integer.parseInt(configuration.getPort())]);
+        dataSource.setPortNumbers(new int[]{Integer.parseInt(configuration.getPort())});
         dataSource.setUser(configuration.getUserName());
         dataSource.setServerName(configuration.getHost());
         dataSource.setDatabaseName(configuration.getDatabaseName());


### PR DESCRIPTION
Fixes issue where only port 5432 was being used because the int port number array was not initialized with a value.

To reproduce: Set any port number different than 5432, test resource, verify it's still using 5432. If your database is on port 5432 you'll see success.

With the fix: Set any port number different than 5432, test resource, verify it's now using the specified port. If your database is on port 5432 you'll see an error, otherwise success.