### PR TITLE
Configure db schema and prefix

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConfiguration.java
@@ -33,8 +33,10 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
     private String databaseName;
     private GuardedString password;
     private String userName;
-    private String port;
+    private String port = "5432";
     private String host;
+    private String schema = "public";
+    private String tablePrefix = "gp";
     private String[] extendedGroupProperties = {};
     private String[] extendedSubjectProperties = {};
     private String[] attrsToHaveInAllSearch = {};
@@ -53,11 +55,6 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         if (host != null && !host.isEmpty()) {
         } else {
             parameters.add("host");
-        }
-
-        if (port != null && !port.isEmpty()) {
-        } else {
-            parameters.add("port");
         }
 
         if (databaseName != null && !databaseName.isEmpty()) {
@@ -161,8 +158,31 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.databaseName = databaseName;
     }
 
-
     @ConfigurationProperty(order = 7,
+            displayMessageKey = "schema.display",
+            helpMessageKey = "schema.help",
+            required = true)
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    @ConfigurationProperty(order = 8,
+            displayMessageKey = "tablePrefix.display",
+            helpMessageKey = "tablePrefix.help",
+            required = true)
+    public String getTablePrefix() {
+        return tablePrefix;
+    }
+
+    public void setTablePrefix(String tablePrefix) {
+        this.tablePrefix = tablePrefix;
+    }
+
+    @ConfigurationProperty(order = 9,
             displayMessageKey = "connectionValidTimeout.display",
             helpMessageKey = "connectionValidTimeout.help")
     public Integer getConnectionValidTimeout() {
@@ -173,7 +193,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.connectionValidTimeout = connectionValidTimeout;
     }
 
-    @ConfigurationProperty(order = 8, displayMessageKey = "extendedGroupProperties.display",
+    @ConfigurationProperty(order = 10, displayMessageKey = "extendedGroupProperties.display",
             helpMessageKey = "extendedGroupProperties.help")
 
     public String[] getExtendedGroupProperties() {
@@ -184,7 +204,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.extendedGroupProperties = extendedGroupProperties;
     }
 
-    @ConfigurationProperty(order = 9, displayMessageKey = "extendedSubjectProperties.display",
+    @ConfigurationProperty(order = 11, displayMessageKey = "extendedSubjectProperties.display",
             helpMessageKey = "extendedSubjectProperties.help")
 
     public String[] getExtendedSubjectProperties() {
@@ -195,7 +215,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.extendedSubjectProperties = extendedSubjectProperties;
     }
 
-    @ConfigurationProperty(order = 10, displayMessageKey = "excludeDeletedObjects.display",
+    @ConfigurationProperty(order = 12, displayMessageKey = "excludeDeletedObjects.display",
             helpMessageKey = "excludeDeletedObjects.help")
 
     public Boolean getExcludeDeletedObjects() {
@@ -206,7 +226,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.excludeDeletedObjects = excludeDeletedObjects;
     }
 
-    @ConfigurationProperty(order = 11, displayMessageKey = "enableIdBasedPaging.display",
+    @ConfigurationProperty(order = 13, displayMessageKey = "enableIdBasedPaging.display",
             helpMessageKey = "enableIdBasedPaging.help")
 
     public Boolean getEnableIdBasedPaging() {
@@ -217,7 +237,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.enableIdBasedPaging = enableIdBasedPaging;
     }
 
-    @ConfigurationProperty(order = 12, displayMessageKey = "maxPageSize.display",
+    @ConfigurationProperty(order = 14, displayMessageKey = "maxPageSize.display",
             helpMessageKey = "maxPageSize.help")
 
     public Integer getMaxPageSize() {
@@ -228,7 +248,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         this.maxPageSize = maxPageSize;
     }
 
-    @ConfigurationProperty(order = 13, displayMessageKey = "attrsToHaveInAllSearch.display",
+    @ConfigurationProperty(order = 15, displayMessageKey = "attrsToHaveInAllSearch.display",
             helpMessageKey = "attrsToHaveInAllSearch.help")
 
     public String[] getAttrsToHaveInAllSearch() {
@@ -248,6 +268,8 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
         userName = null;
         port = null;
         host = null;
+        schema = null;
+        tablePrefix = null;
         extendedSubjectProperties = null;
         extendedGroupProperties = null;
         excludeDeletedObjects = true;

--- a/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConnection.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConnection.java
@@ -44,8 +44,9 @@ public class GrouperConnection {
         Connection connection;
         dataSource.setPortNumbers(new int[]{Integer.parseInt(configuration.getPort())});
         dataSource.setUser(configuration.getUserName());
-        dataSource.setServerName(configuration.getHost());
+        dataSource.setServerNames(new String[]{configuration.getHost()});
         dataSource.setDatabaseName(configuration.getDatabaseName());
+        dataSource.setCurrentSchema(configuration.getSchema());
 
         GuardedString clientPassword = configuration.getPassword();
         GuardedStringAccessor accessorSecret = new GuardedStringAccessor();

--- a/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConnection.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConnection.java
@@ -42,7 +42,7 @@ public class GrouperConnection {
     private static Connection initialize(GrouperConfiguration configuration) {
         final PGConnectionPoolDataSource dataSource = new PGConnectionPoolDataSource();
         Connection connection;
-        dataSource.setPortNumbers(new int[Integer.parseInt(configuration.getPort())]);
+        dataSource.setPortNumbers(new int[]{Integer.parseInt(configuration.getPort())});
         dataSource.setUser(configuration.getUserName());
         dataSource.setServerName(configuration.getHost());
         dataSource.setDatabaseName(configuration.getDatabaseName());

--- a/src/main/java/com/evolveum/polygon/connector/grouper/util/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/util/GroupProcessing.java
@@ -33,8 +33,8 @@ public class GroupProcessing extends ObjectProcessing {
     private static final String ATTR_DISPLAY_NAME = "display_name";
     private static final String ATTR_DESCRIPTION = "description";
     private static final String ATTR_ID_IDX = "id_index";
-    protected static final String TABLE_GR_NAME = "gr_mp_groups";
-    private static final String TABLE_GR_EXTENSION_NAME = "gr_mp_group_attributes";
+    protected static final String NO_PREFIX_TABLE_GR_NAME = "_mp_groups";
+    private static final String NO_PREFIX_TABLE_GR_EXTENSION_NAME = "_mp_group_attributes";
     protected static final String ATTR_UID = ATTR_ID_IDX;
     protected static final String ATTR_NAME = "group_name";
     protected static final String ATTR_MEMBERS = "members";
@@ -42,6 +42,8 @@ public class GroupProcessing extends ObjectProcessing {
 
     protected Set<String> multiValuedAttributesCatalogue = new HashSet();
     protected Map<String, Class> columns = new HashMap<>();
+    protected static String TABLE_GR_NAME = null;
+    protected static String TABLE_GR_EXTENSION_NAME = null;
     public static final ObjectClass O_CLASS = new ObjectClass(GROUP_NAME);
 
     protected Map<String, Class> objectConstructionSchema = Map.ofEntries(
@@ -58,6 +60,9 @@ public class GroupProcessing extends ObjectProcessing {
     public GroupProcessing(GrouperConfiguration configuration) {
 
         super(configuration);
+
+        TABLE_GR_NAME = configuration.getTablePrefix() + NO_PREFIX_TABLE_GR_NAME;
+        TABLE_GR_EXTENSION_NAME = configuration.getTablePrefix() + NO_PREFIX_TABLE_GR_EXTENSION_NAME;
 
         columns.put(ATTR_NAME, String.class);
         columns.put(ATTR_DISPLAY_NAME, String.class);

--- a/src/main/java/com/evolveum/polygon/connector/grouper/util/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/util/ObjectProcessing.java
@@ -29,7 +29,7 @@ public abstract class ObjectProcessing {
     public static final String SUBJECT_NAME = "subject";
     public static final String GROUP_NAME = "group";
     protected static final String ATTR_MODIFIED = "last_modified";
-    protected static final String TABLE_MEMBERSHIP_NAME = "gr_mp_memberships";
+    protected static final String NO_PREFIX_TABLE_MEMBERSHIP_NAME = "_mp_memberships";
     protected static final String ATTR_GR_ID_IDX = "group_id_index";
     protected static final String ATTR_SCT_ID_IDX = "subject_id_index";
     protected static final String ATTR_EXT_NAME = "attribute_name";
@@ -38,6 +38,7 @@ public abstract class ObjectProcessing {
     protected static final String ATTR_DELETED_TRUE = "T";
     protected static final String ATTR_MODIFIED_LATEST = "latest_timestamp";
     private static final String _COUNT = "count";
+    protected static String TABLE_MEMBERSHIP_NAME = null;
     protected GrouperConfiguration configuration;
 
     protected Map<String, Class> objectColumns = Map.ofEntries(
@@ -63,6 +64,8 @@ public abstract class ObjectProcessing {
     public ObjectProcessing(GrouperConfiguration configuration) {
 
         this.configuration = configuration;
+
+        TABLE_MEMBERSHIP_NAME = configuration.getTablePrefix() + NO_PREFIX_TABLE_MEMBERSHIP_NAME;
     }
 
     public abstract void buildObjectClass(SchemaBuilder schemaBuilder, GrouperConfiguration configuration);

--- a/src/main/java/com/evolveum/polygon/connector/grouper/util/SubjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/util/SubjectProcessing.java
@@ -32,14 +32,16 @@ public class SubjectProcessing extends ObjectProcessing {
     private static final Log LOG = Log.getLog(SubjectProcessing.class);
     private static final String ATTR_ID = "subject_id";
     private static final String ATTR_ID_IDX = "subject_id_index";
-    protected static final String TABLE_SU_NAME = "gr_mp_subjects";
-    private static final String TABLE_SU_EXTENSION_NAME = "gr_mp_subject_attributes";
+    protected static final String NO_PREFIX_TABLE_SU_NAME = "_mp_subjects";
+    private static final String NO_PREFIX_TABLE_SU_EXTENSION_NAME = "_mp_subject_attributes";
     public static final ObjectClass O_CLASS = new ObjectClass(SUBJECT_NAME);
     protected static final String ATTR_UID = ATTR_ID_IDX;
     protected static final String ATTR_NAME = ATTR_ID;
     protected static final String ATTR_MEMBER_OF = "member_of";
     protected static final String ATTR_MEMBER_OF_NATIVE = ATTR_GR_ID_IDX;
 
+    protected static String TABLE_SU_NAME = null;
+    private static String TABLE_SU_EXTENSION_NAME = null;
     protected Set<String> multiValuedAttributesCatalogue = new HashSet();
     protected Map<String, Class> columns = new HashMap<>();
     protected Map<String, Class> suMembershipColumns = Map.ofEntries(
@@ -61,6 +63,9 @@ public class SubjectProcessing extends ObjectProcessing {
     public SubjectProcessing(GrouperConfiguration configuration) {
 
         super(configuration);
+
+        TABLE_SU_NAME = configuration.getTablePrefix() + NO_PREFIX_TABLE_SU_NAME;
+        TABLE_SU_EXTENSION_NAME = configuration.getTablePrefix() + NO_PREFIX_TABLE_SU_EXTENSION_NAME;
 
         columns.put(ATTR_ID_IDX, Long.class);
         columns.put(ATTR_ID, String.class);

--- a/src/main/resources/com/evolveum/polygon/connector/grouper/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/grouper/Messages.properties
@@ -15,11 +15,15 @@
 #
 grouper.connector.display=Grouper
 host.display=Host
-host.help=Enter the Hostname / ulr pointing to the grouper database.
+host.help=Enter the Hostname / URL pointing to the database server.
 port.display=TCP Port
-port.help=Enter the port number for the connection to the database server.
+port.help=Enter the port number for the connection to the database server. Defaults to 5432 if none is specified.
 databaseName.display=Database name
-databaseName.help=Name of the database schema containing grouper object tables.
+databaseName.help=Name of the database containing grouper object tables.
+schema.display=Database Schema
+schema.help=Database schema if applicable. Defaults to "public" if not supplied and the database supports it.
+tablePrefix.display=Table Prefix
+tablePrefix.help=The prefix of the tables if you've changed them in the Grouper midPoint provisioner. Default is "gr".
 connectionValidTimeout.display=Validation Timeout
 connectionValidTimeout.help=The number of seconds which represent the limit for connection validation. Setting this parameter to '0' means indefinite.[default value is 10]
 userName.display=User Name

--- a/src/test/java/com/evolveum/polygon/connector/grouper/unit/Misc.java
+++ b/src/test/java/com/evolveum/polygon/connector/grouper/unit/Misc.java
@@ -33,7 +33,7 @@ public class Misc extends CommonTestClass {
     public void inHighVolume() {
         GrouperConnection grouperConnection = new GrouperConnection(grouperConfiguration);
 
-        String query = "SELECT * FROM public.gr_mp_subjects WHERE subject_id_index IN(";
+        String query = "SELECT * FROM " + grouperConfiguration.getSchema() + "." + grouperConfiguration.getTablePrefix() + "_mp_subjects WHERE subject_id_index IN(";
         for (int i = 0; MAX_IN >= i; i++) {
 
             query = query + i;


### PR DESCRIPTION
Add the option to configure database schema name and table prefix. Also sets defaults if none are supplied.

To test: Create a database of any name on any port. Create a schema different then public, I used "grouper" because that's what my client used.

Then add something like this for your ddl:

```
CREATE TABLE pgr_mp_groups (
    group_name varchar(1024) NULL, -- Name of group mapped in some way
    id_index int8 NOT NULL, -- This is the integer identifier for a group and foreign key to group attributes and memberships
    display_name varchar(1024) NULL, -- Display name of group mapped in some way
    description varchar(1024) NULL, -- Description of group mapped in some way
    last_modified int8 NOT NULL, -- Millis since 1970, will be sequential and unique
    deleted varchar(1) NOT NULL, -- T or F.  Deleted rows will be removed after they have had time to be processed
    CONSTRAINT pgr_mp_groups_pkey PRIMARY KEY (id_index)
);
CREATE INDEX pgr_mp_groups_ddx ON pgr_mp_groups(display_name);
CREATE INDEX pgr_mp_groups_gdx ON pgr_mp_groups(group_name);
CREATE UNIQUE INDEX pgr_mp_groups_idx ON pgr_mp_groups(id_index);
CREATE UNIQUE INDEX pgr_mp_groups_ldx ON pgr_mp_groups(last_modified);
COMMENT ON TABLE pgr_mp_groups IS 'This table holds groups';
 
COMMENT ON COLUMN pgr_mp_groups.group_name IS 'Name of group mapped in some way';
COMMENT ON COLUMN pgr_mp_groups.id_index IS 'This is the integer identifier for a group and foreign key to group attributes and memberships';
COMMENT ON COLUMN pgr_mp_groups.display_name IS 'Display name of group mapped in some way';
COMMENT ON COLUMN pgr_mp_groups.description IS 'Description of group mapped in some way';
COMMENT ON COLUMN pgr_mp_groups.last_modified IS 'Millis since 1970, will be sequential and unique';
COMMENT ON COLUMN pgr_mp_groups.deleted IS 'T or F.  Deleted rows will be removed after they have had time to be processed';
 
CREATE TABLE pgr_mp_subjects (
    subject_id_index int8 NOT NULL, -- This is the integer identifier for a subject and foreign key to subject attributes and memberships
    subject_id varchar(1024) NULL, -- Subject ID mapped in some way
    last_modified int8 NOT NULL, -- Millis since 1970, will be sequential and unique
    deleted varchar(1) NOT NULL, -- T or F.  Deleted rows will be removed after they have had time to be processed
    CONSTRAINT pgr_mp_subjects_pkey PRIMARY KEY (subject_id_index)
);
CREATE UNIQUE INDEX pgr_mp_subjects_idx ON pgr_mp_subjects(subject_id_index);
CREATE UNIQUE INDEX pgr_mp_subjects_ldx ON pgr_mp_subjects(last_modified);
CREATE INDEX pgr_mp_subjects_sdx ON pgr_mp_subjects(subject_id);
COMMENT ON TABLE pgr_mp_subjects IS 'This table holds subjects';
 
COMMENT ON COLUMN pgr_mp_subjects.subject_id_index IS 'This is the integer identifier for a subject and foreign key to subject attributes and memberships';
COMMENT ON COLUMN pgr_mp_subjects.subject_id IS 'Subject ID mapped in some way';
COMMENT ON COLUMN pgr_mp_subjects.last_modified IS 'Millis since 1970, will be sequential and unique';
COMMENT ON COLUMN pgr_mp_subjects.deleted IS 'T or F.  Deleted rows will be removed after they have had time to be processed';
 
CREATE TABLE pgr_mp_group_attributes (
    group_id_index int8 NOT NULL, -- This is the integer identifier for a group and foreign key to groups and memberships
    attribute_name varchar(1000) NOT NULL, -- Attribute name for attributes not in the main group table
    attribute_value varchar(4000) NULL, -- Attribute value could be null
    last_modified int8 NOT NULL, -- Millis since 1970, will be sequential and unique
    deleted varchar(1) NOT NULL, -- T or F.  Deleted rows will be removed after they have had time to be processed
    CONSTRAINT pgr_mp_group_attributes_fk FOREIGN KEY (group_id_index) REFERENCES pgr_mp_groups(id_index) ON DELETE CASCADE
 );
CREATE UNIQUE INDEX pgr_mp_group_attributes_idx ON pgr_mp_group_attributes(group_id_index, attribute_name, attribute_value);
CREATE UNIQUE INDEX pgr_mp_group_attributes_ldx ON pgr_mp_group_attributes(last_modified);
COMMENT ON TABLE pgr_mp_group_attributes IS 'This table holds group attributes which are one to one or one to many to the groups table';
 
COMMENT ON COLUMN pgr_mp_group_attributes.group_id_index IS 'This is the integer identifier for a group and foreign key to groups and memberships';
COMMENT ON COLUMN pgr_mp_group_attributes.attribute_name IS 'Attribute name for attributes not in the main group table';
COMMENT ON COLUMN pgr_mp_group_attributes.attribute_value IS 'Attribute value could be null';
COMMENT ON COLUMN pgr_mp_group_attributes.last_modified IS 'Millis since 1970, will be sequential and unique';
COMMENT ON COLUMN pgr_mp_group_attributes.deleted IS 'T or F.  Deleted rows will be removed after they have had time to be processed';
 
CREATE TABLE pgr_mp_memberships (
    group_id_index int8 NOT NULL, -- This is the foreign key to groups
    subject_id_index int8 NOT NULL, -- This is the foreign key to subjects
    last_modified int8 NOT NULL, -- Millis since 1970, will be sequential and unique
    deleted varchar(1) NOT NULL, -- T or F.  Deleted rows will be removed after they have had time to be processed
    CONSTRAINT pgr_mp_memberships_gfk FOREIGN KEY (group_id_index) REFERENCES pgr_mp_groups(id_index) ON DELETE CASCADE,
    CONSTRAINT pgr_mp_memberships_sfk FOREIGN KEY (subject_id_index) REFERENCES pgr_mp_subjects(subject_id_index) ON DELETE CASCADE
 );
CREATE UNIQUE INDEX pgr_mp_memberships_idx ON pgr_mp_memberships(group_id_index, subject_id_index);
CREATE UNIQUE INDEX pgr_mp_memberships_ldx ON pgr_mp_memberships(last_modified);
COMMENT ON TABLE pgr_mp_memberships IS 'This table holds memberships.  The primary key is group_id_index and subject_id_index';
 
COMMENT ON COLUMN pgr_mp_memberships.group_id_index IS 'This is the foreign key to groups';
COMMENT ON COLUMN pgr_mp_memberships.subject_id_index IS 'This is the foreign key to subjects';
COMMENT ON COLUMN pgr_mp_memberships.last_modified IS 'Millis since 1970, will be sequential and unique';
COMMENT ON COLUMN pgr_mp_memberships.deleted IS 'T or F.  Deleted rows will be removed after they have had time to be processed';
 
CREATE TABLE pgr_mp_subject_attributes (
    subject_id_index int8 NOT NULL, -- This is the integer identifier and foreign key to subjects
    attribute_name varchar(1000) NOT NULL, -- Attribute name for attributes not in the main subject table
    attribute_value varchar(4000) NULL, -- Attribute value could be null
    last_modified int8 NOT NULL, -- Millis since 1970, will be sequential and unique
    deleted varchar(1) NOT NULL, -- T or F.  Deleted rows will be removed after they have had time to be processed
    CONSTRAINT pgr_mp_subject_attributes_fk FOREIGN KEY (subject_id_index) REFERENCES pgr_mp_subjects(subject_id_index) ON DELETE CASCADE
 );
CREATE UNIQUE INDEX pgr_mp_subject_attributes_idx ON pgr_mp_subject_attributes(subject_id_index, attribute_name, attribute_value);
CREATE UNIQUE INDEX pgr_mp_subject_attributes_ldx ON pgr_mp_subject_attributes(last_modified);
COMMENT ON TABLE pgr_mp_subject_attributes IS 'This table holds subject attributes which are one to one or one to many to the subjects table';
 
COMMENT ON COLUMN pgr_mp_subject_attributes.subject_id_index IS 'This is the integer identifier and foreign key to subjects';
COMMENT ON COLUMN pgr_mp_subject_attributes.attribute_name IS 'Attribute name for attributes not in the main subject table';
COMMENT ON COLUMN pgr_mp_subject_attributes.attribute_value IS 'Attribute value could be null';
COMMENT ON COLUMN pgr_mp_subject_attributes.last_modified IS 'Millis since 1970, will be sequential and unique';
COMMENT ON COLUMN pgr_mp_subject_attributes.deleted IS 'T or F.  Deleted rows will be removed after they have had time to be processed';
```

In the connector configuration ensure the schema config is set to the schema you created above and that the Table Prefix is set to pgr. The Grouper midPoint SQL provisioner allows table prefix to be set/changed. This accomodates the configuration on that end. 

 