### PR TITLE
Update GrouperConfiguration.java- Changed table prefix to gr

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/grouper/GrouperConfiguration.java
@@ -36,7 +36,7 @@ public class GrouperConfiguration extends AbstractConfiguration implements State
     private String port = "5432";
     private String host;
     private String schema = "public";
-    private String tablePrefix = "gp";
+    private String tablePrefix = "gr";
     private String[] extendedGroupProperties = {};
     private String[] extendedSubjectProperties = {};
     private String[] attrsToHaveInAllSearch = {};


### PR DESCRIPTION
The default table prefix currently is gp which is different from the grouper provisioner documentation where the table prefix is gr. This change helps make sure users do not have to make changes to the default configuration for the grouper connector to work. For reference - 

The url for grouper midpoint provisioner is - https://spaces.at.internet2.edu/display/Grouper/Grouper+MidPoint+provisioner

Which states that 


"Provisioner Configuration
midPoint provisioner is essentially a trimmed-down version of SQL provisioner. You only need to enter the prefix for the tables, and it assumes the rest of the part. For example gr is the prefix configured in the screenshot below and grouper assumes that the table names are going to look like gr_mp_groups, gr_mp_memberships, etc." 

This change will make sure there is  consistency between two different Open source systems.